### PR TITLE
Make images on blog posts responsive

### DIFF
--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -3,6 +3,7 @@ import { Post as PostModel } from "../models/Post"
 import { formatDate } from "date-fns";
 import Markdown from "markdown-to-jsx";
 import Code from "./Code";
+import ScalableImage from "./ScalableImage";
 
 interface PostProps {
   post: PostModel;
@@ -27,7 +28,10 @@ export default function Post({ post }: PostProps) {
                 overrides: {
                   Code: {
                     component: Code
-                  }
+                  },
+                  img: {
+                    component: ScalableImage,
+                  },
                 }
               }}>{post.content}</Markdown>
             </Typography>

--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -3,7 +3,7 @@ import { Post as PostModel } from "../models/Post"
 import { formatDate } from "date-fns";
 import Markdown from "markdown-to-jsx";
 import Code from "./Code";
-import ScalableImage from "./ScalableImage";
+import ResponsiveImage from "./ResponsiveImage";
 
 interface PostProps {
   post: PostModel;
@@ -30,7 +30,7 @@ export default function Post({ post }: PostProps) {
                     component: Code
                   },
                   img: {
-                    component: ScalableImage,
+                    component: ResponsiveImage,
                   },
                 }
               }}>{post.content}</Markdown>

--- a/src/components/ResponsiveImage.tsx
+++ b/src/components/ResponsiveImage.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react";
 
-interface ScalableImageProps {
+interface ResponsiveImageProps {
   alt: string;
   src: string;
 }
 
-export default function ScalableImage({ alt, src }: ScalableImageProps) {
+export default function ResponsiveImage({ alt, src }: ResponsiveImageProps) {
   let image = new Image();
   image.src = src;
 

--- a/src/components/ScalableImage.tsx
+++ b/src/components/ScalableImage.tsx
@@ -1,0 +1,34 @@
+import { useState } from "react";
+
+interface ScalableImageProps {
+  alt: string;
+  src: string;
+}
+
+export default function ScalableImage({ alt, src }: ScalableImageProps) {
+  let image = new Image();
+  image.src = src;
+
+  // This is a hacky way to determine if the image is portrait or landscape
+  // Portrait images are way too big when you use 25vw
+  var [imageWidth, setImageWidth] = useState("");
+  image.onload = () => {
+    if (image.naturalHeight > image.naturalWidth) {
+      // Portrait
+      setImageWidth("15vw");
+    } else {
+      // Landscape
+      setImageWidth("25vw");
+    }
+  };
+
+  return (
+    <>
+      <img
+        src={src}
+        alt={alt}
+        style={{ width: imageWidth, minWidth: "290px" }}
+      ></img>
+    </>
+  );
+}


### PR DESCRIPTION
Hey, while reading your blog post on my phone, I encountered an issue with images, they are not scaling therefore causing them to go out of container boundaries (screenshot below):

<img src='https://github.com/tsunyoku/blog/assets/64559993/944f31b5-60e8-44b2-abd9-91948ae02b1e' width='300'>

The PR aims to fix that issue by creating ResponsiveImage component, which automatically detects if an image is portrait or landscape and scales it according to image size type (expected result below):

<img src='https://github.com/tsunyoku/blog/assets/64559993/7d7e95b1-1511-4681-934b-94eac8ca37f7' width='400'>